### PR TITLE
Wrapped objects need to be accessible after disposal.

### DIFF
--- a/src/InstrumentedAdoNet/InstrumentedDbCommand.cs
+++ b/src/InstrumentedAdoNet/InstrumentedDbCommand.cs
@@ -13,10 +13,11 @@ namespace InstrumentedAdoNet
     /// </summary>
     public partial class InstrumentedDbCommand : DbCommand
     {
-        private DbCommand _command;
+        private readonly DbCommand _command;
         private IInstrumentationHandler _instrumentationHandler;
         private DbConnection _connection;
         private DbTransaction _transaction;
+        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstrumentedDbCommand"/> class.
@@ -345,11 +346,11 @@ namespace InstrumentedAdoNet
         /// <param name="disposing">false if this is being disposed in a <c>finalizer</c>.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && this._command != null)
+            if (disposing && !this._disposed)
             {
                 this._command.Dispose();
+                this._disposed = true;
             }
-            this._command = null;
             base.Dispose(disposing);
         }
 

--- a/src/InstrumentedAdoNet/InstrumentedDbConnection.cs
+++ b/src/InstrumentedAdoNet/InstrumentedDbConnection.cs
@@ -12,7 +12,8 @@ namespace InstrumentedAdoNet
     [System.ComponentModel.DesignerCategory("")]
     public class InstrumentedDbConnection : DbConnection
     {
-        private DbConnection _connection;
+        private readonly DbConnection _connection;
+        private bool _disposed;
         private IInstrumentationHandler _instrumentationHandler;
 
         /// <summary>
@@ -140,13 +141,13 @@ namespace InstrumentedAdoNet
         /// <param name="disposing">false if preempted from a <c>finalizer</c></param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && this._connection != null)
+            if (disposing && !this._disposed)
             {
                 this._connection.StateChange -= this.StateChangeHandler;
                 this._connection.Dispose();
+                this._disposed = true;
             }
             base.Dispose(disposing);
-            this._connection = null;
             this._instrumentationHandler = null;
         }
 

--- a/src/InstrumentedAdoNet/InstrumentedDbTransaction.cs
+++ b/src/InstrumentedAdoNet/InstrumentedDbTransaction.cs
@@ -10,7 +10,8 @@ namespace InstrumentedAdoNet
     public class InstrumentedDbTransaction : DbTransaction
     {
         private InstrumentedDbConnection _connection;
-        private DbTransaction _transaction;
+        private readonly DbTransaction _transaction;
+        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstrumentedDbTransaction"/> class.
@@ -55,11 +56,11 @@ namespace InstrumentedAdoNet
         /// <param name="disposing">false if being called from a <c>finalizer</c></param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && this._transaction != null)
+            if (disposing && !this._disposed)
             {
                 this._transaction.Dispose();
+                this._disposed = true;
             }
-            this._transaction = null;
             this._connection = null;
             base.Dispose(disposing);
         }


### PR DESCRIPTION
Various logging solutions are experiencing the NRE problem if they attempt to access properties of the wrapped objects after they have been disposed.
Sometimes it's a valid scenario, for example:
DbConnection.ConnectionString should be accessible even after disposal, while the InstrumentedDbConnection raises NRE instead of returning the connection string or null.